### PR TITLE
fixes #43 - unsetting macros from hotbar does not require "-=" syntax anymore

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -78,6 +78,7 @@ export class TokenHotbarController {
 
     /**
      * Transforms `-=<slot>` keys into `<slot>`
+     * This method may be unnecessary?
      * @param hotbarUpdate
      */
     private transformHotbarUpdate(hotbarUpdate: HotbarSlots) {

--- a/src/flags/hotbarFlags.ts
+++ b/src/flags/hotbarFlags.ts
@@ -47,7 +47,7 @@ export class ModuleHotbarFlags implements HotbarFlags {
             for (const slot in data[tokenId]) {
                 if (!data[tokenId][slot]) {
                     delete data[tokenId][slot];
-                    data[tokenId][`-=${slot}`] = null;
+                    //data[tokenId][`-=${slot}`] = null;
                 }
             }
         }

--- a/src/hotbar/foundryHotbar.ts
+++ b/src/hotbar/foundryHotbar.ts
@@ -85,7 +85,7 @@ export class FoundryHotbar implements UiHotbar, Hotbar {
 
     private unset(hotbar, slot: number) {
         delete hotbar[slot];
-        hotbar[`-=${slot}`] = null;
+        //hotbar[`-=${slot}`] = null;  <- This breaks 0.8.8.
     }
 
     private getAllHotbarMacros(): HotbarSlots {

--- a/src/hotbar/hotbar.ts
+++ b/src/hotbar/hotbar.ts
@@ -1,7 +1,7 @@
 import { IActor, IToken } from "../utils/foundry";
 
 /**
- * slot is usually a number, but in order to unset it it sometimes has to be `-=<slot>`
+ * slot is a number.
  */
 export type HotbarSlots = { [slot: number] : string | undefined }
 export type HotbarSlot = { slot: number, macroId: string }


### PR DESCRIPTION
It seems with new foundry syntax of "-=<slot_number>" causes validations to fail. It SEEMS it is enough to delete it from array to clear it.